### PR TITLE
Fixed several variable name errors.

### DIFF
--- a/src/twgl.js
+++ b/src/twgl.js
@@ -501,7 +501,7 @@ define([], function () {
       }
       if ((type === gl.SAMPLER_2D || type === gl.SAMPLER_CUBE) && isArray) {
         var units = [];
-        for (var ii = 0; ii < info.size; ++ii) {
+        for (var ii = 0; ii < uniformInfo.size; ++ii) {
           units.push(textureUnit++);
         }
         return function(bindPoint, units) {
@@ -509,7 +509,7 @@ define([], function () {
             gl.uniform1iv(location, units);
             textures.forEach(function(texture, index) {
               gl.activeTexture(gl.TEXTURE0 + units[index]);
-              gl.bindTexture(bindPoint, tetxure);
+              gl.bindTexture(bindPoint, texture);
             });
           };
         }(getBindPointForSamplerType(gl, type), units);
@@ -1160,7 +1160,7 @@ define([], function () {
       var numComponents = array.numComponents || guessNumComponentsFromName(key, length);
       var numElements = length / numComponents;
       if (length % numComponents > 0) {
-        throw "numComponents " + numComponent + " not correct for length " + length;
+        throw "numComponents " + numComponents + " not correct for length " + length;
       }
       return numElements;
     };
@@ -1310,7 +1310,7 @@ define([], function () {
     var buffers = { };
     Object.keys(arrays).forEach(function(key) {
       var type = key === "indices" ? gl.ELEMENT_ARRAY_BUFFER : gl.ARRAY_BUFFER;
-      var array = makeTypedArray(arrays[key], name);
+      var array = makeTypedArray(arrays[key], key);
       buffers[key] = createBufferFromTypedArray(gl, array, type);
     });
 
@@ -1845,7 +1845,7 @@ define([], function () {
     setTextureTo1PixelColor(gl, tex, options);
     // Because it's async we need to copy the options.
     options = shallowCopy(options);
-    img = loadImage(options.src, function(err, img) {
+    var img = loadImage(options.src, function(err, img) {
       if (err) {
         callback(err, tex, img);
       } else {
@@ -1944,7 +1944,7 @@ define([], function () {
       case RGBA:
         return 4;
       default:
-        throw "unknown type: " + type;
+        throw "unknown type: " + format;
     }
   }
 


### PR DESCRIPTION
Hi Greg,

My js2-mode for emacs highlights several variable reference errors.
These are usually typos, referencing undefined variables, where another one was obviously intended.
In one case I added 'var' to make a variable local.

I ran all the examples to make sure I didn't break anything.


