### PR TITLE
Permit passing indices of type Uint32Array in createBufferInfoFromArrays

### DIFF
--- a/src/twgl.js
+++ b/src/twgl.js
@@ -1275,6 +1275,7 @@ define([], function () {
       indices = makeTypedArray(indices, "indices");
       bufferInfo.indices = createBufferFromTypedArray(gl, indices, gl.ELEMENT_ARRAY_BUFFER);
       bufferInfo.numElements = indices.length;
+      bufferInfo.elementType = (indices instanceof Uint32Array) ?  gl.UNSIGNED_INT : gl.UNSIGNED_SHORT;
     } else {
       bufferInfo.numElements = getNumElementsFromNonIndexedArrays(arrays);
     }
@@ -1336,7 +1337,7 @@ define([], function () {
     var numElements = count === undefined ? bufferInfo.numElements : count;
     offset = offset === undefined ? 0 : offset;
     if (indices) {
-      gl.drawElements(type, numElements, gl.UNSIGNED_SHORT, offset);
+      gl.drawElements(type, numElements, bufferInfo.elementType === undefined ? gl.UNSIGNED_SHORT : bufferInfo.elementType, offset);
     } else {
       gl.drawArrays(type, offset, numElements);
     }


### PR DESCRIPTION
Many browsers support the OES_element_index_uint extension, permitting
drawElements to operate using 32-bit element indexes. In
createBufferInfoFromArrays, when creating the buffer for indices,
record the element type of the indices elements in a new property,
bufferInfo.elementType. Later, when calling  drawElements, use the value
of bufferInfo.elementType.

If the calling program needs to use 32 bit int indexes, it should call
gl.getExtension("OES_element_index_uint"); if the extension is available,
then it can pass a Unit32Array in the indices property.

  var arrays = {
    position: [-1, -1, 0, 1, -1, 0, -1, 1, 0, 1, 1, 0],
    indices:  new Uint32Array([ 0, 1, 2, 2, 1, 3])
  };
  var bufferInfo = twgl.createBufferInfoFromArrays(gl, arrays);