### PR TITLE
adding cross-origin loading of images support

### DIFF
--- a/src/twgl.js
+++ b/src/twgl.js
@@ -1905,6 +1905,7 @@ define([], function () {
   function loadImage(url, callback) {
     callback = callback || noop;
     var img = new Image();
+    img.crossOrigin = '';
     img.onerror = function() {
       var msg = "couldn't load image: " + url;
       error(msg);
@@ -2724,4 +2725,3 @@ define([], function () {
   };
 
 });
-


### PR DESCRIPTION
Add support for loading images cross-origin. Without this twgl.js and images have to be on the same domain; with this fix, its no longer an issue.

http://blog.chromium.org/2011/07/using-cross-domain-images-in-webgl-and.html