### PR TITLE
fix drawObjectList when type is gl.POINTS

### DIFF
--- a/src/draw.js
+++ b/src/draw.js
@@ -125,6 +125,7 @@ define([
       var programInfo = object.programInfo;
       var bufferInfo = object.vertexArrayInfo || object.bufferInfo;
       var bindBuffers = false;
+      var type = object.type === undefined ? gl.TRIANGLES : object.type;
 
       if (programInfo !== lastUsedProgramInfo) {
         lastUsedProgramInfo = programInfo;
@@ -150,7 +151,7 @@ define([
       programs.setUniforms(programInfo, object.uniforms);
 
       // Draw
-      drawBufferInfo(gl, object.type || gl.TRIANGLES, bufferInfo, object.count, object.offset);
+      drawBufferInfo(gl, type, bufferInfo, object.count, object.offset);
     });
 
     if (lastUsedBufferInfo.vertexArrayObject) {


### PR DESCRIPTION
Currently the drawObjectList function will always default to `object.type = gl.TRIANGLES` when setting type to `gl.POINTS` because `gl.POINTS` is `0` and therefore always falsy.

The changes in this PR will check if `object.type` is defined at all and default to `gl.TRIANGLES` only when `object.type` is `undefined`.

PS: Thanks for the great work!