### PR TITLE
Fix calls to gl.texSubImage3D.

### DIFF
--- a/examples/3d-texture-volume-no-buffers.html
+++ b/examples/3d-texture-volume-no-buffers.html
@@ -138,7 +138,7 @@ function main() {
     ctx.arc(x, y, radius, 0, Math.PI * 2, false);
     ctx.fill();
     gl.bindTexture(gl.TEXTURE_3D, texture);
-    gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, z, gl.RGBA, gl.UNSIGNED_BYTE, ctx.canvas);
+    gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, z, ctx.canvas.width, ctx.canvas.height, 1, gl.RGBA, gl.UNSIGNED_BYTE, ctx.canvas);
   }
 
   function drawCircle(z, color, x, y, radius) {

--- a/examples/3d-texture-volume.html
+++ b/examples/3d-texture-volume.html
@@ -129,7 +129,7 @@ function main() {
     ctx.arc(x, y, radius, 0, Math.PI * 2, false);
     ctx.fill();
     gl.bindTexture(gl.TEXTURE_3D, texture);
-    gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, z, gl.RGBA, gl.UNSIGNED_BYTE, ctx.canvas);
+    gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, z, ctx.canvas.width, ctx.canvas.height, 1, gl.RGBA, gl.UNSIGNED_BYTE, ctx.canvas);
   }
 
   function drawCircle(z, color, x, y, radius) {


### PR DESCRIPTION
Fix 3D texture examples on latest Firefox and Chrome.
```
Uncaught TypeError: Failed to execute 'texSubImage3D' on 'WebGL2RenderingContext': 11 arguments required, but only 8 present.
    at drawCircleLow (3d-texture-volume.html:132)
    at drawCircle (3d-texture-volume.html:147)
    at main (3d-texture-volume.html:166)
    at 3d-texture-volume.html:371
```