### PR TITLE
allow resizeCanvasToDisplaySize reduce the resolution

### DIFF
--- a/src/twgl.js
+++ b/src/twgl.js
@@ -274,13 +274,13 @@ define([
   /**
    * Resize a canvas to match the size it's displayed.
    * @param {HTMLCanvasElement} canvas The canvas to resize.
-   * @param {number} [multiplier] So you can pass in `window.devicePixelRatio` if you want to.
+   * @param {number} [multiplier] So you can pass in `window.devicePixelRatio` or other scale value if you want to.
    * @return {boolean} true if the canvas was resized.
    * @memberOf module:twgl
    */
   function resizeCanvasToDisplaySize(canvas, multiplier) {
     multiplier = multiplier || 1;
-    multiplier = Math.max(1, multiplier);
+    multiplier = Math.max(0, multiplier);
     var width  = canvas.clientWidth  * multiplier | 0;
     var height = canvas.clientHeight * multiplier | 0;
     if (canvas.width !== width ||


### PR DESCRIPTION
By this way, can easily reduce resolution when need optimize in low-power machine.