### PR TITLE
Fixed documentation.

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -210,7 +210,7 @@ function makeTypedArray(array, name) {
  *    If `coord` is in the name assumes `numComponents = 2`.
  *    If `color` is in the name assumes `numComponents = 4`.
  *    otherwise assumes `numComponents = 3`
- * @property {constructor} type The type. This is only used if `data` is a JavaScript array. It is the constructor for the typedarray. (eg. `Uint8Array`).
+ * @property {constructor} [type] type. This is only used if `data` is a JavaScript array. It is the constructor for the typedarray. (eg. `Uint8Array`).
  * For example if you want colors in a `Uint8Array` you might have a `FullArraySpec` like `{ type: Uint8Array, data: [255,0,255,255, ...], }`.
  * @property {number} [size] synonym for `numComponents`.
  * @property {boolean} [normalize] normalize for `vertexAttribPointer`. Default is true if type is `Int8Array` or `Uint8Array` otherwise false.


### PR DESCRIPTION
In the first example of https://twgljs.org/docs/module-twgl.html#.createBufferInfoFromArrays , no `type`argument is given. Also, the code works fine without it, even when using js arrays.