### PR TITLE
Fix missing return type in getWebGLContext docs

### DIFF
--- a/src/twgl.js
+++ b/src/twgl.js
@@ -311,6 +311,7 @@ function create3DContext(canvas, opt_attribs) {
  *
  * @param {HTMLCanvasElement} canvas a canvas element.
  * @param {WebGLContextAttributes} [opt_attribs] optional webgl context creation attributes
+ * @return {WebGLRenderingContext} The created context.
  * @memberOf module:twgl
  */
 function getWebGLContext(canvas, opt_attribs) {


### PR DESCRIPTION
The TypeScript definitions were incorrectly stating the return type of getWebGLContext as void because the docstring was missing the return type. (specifically, WebGLRenderingContext)