### PR TITLE
Fixes uncaught TypeError in certain conditions

### DIFF
--- a/src/draw.js
+++ b/src/draw.js
@@ -153,7 +153,7 @@ function drawObjectList(gl, objectsToDraw) {
     drawBufferInfo(gl, bufferInfo, type, object.count, object.offset, object.instanceCount);
   });
 
-  if (lastUsedBufferInfo.vertexArrayObject) {
+  if (lastUsedBufferInfo && lastUsedBufferInfo.vertexArrayObject) {
     gl.bindVertexArray(null);
   }
 }


### PR DESCRIPTION
In this loop, there is no guarantee that `lastUsedBufferInfo` is not `null` at the time that this conditional is reached. Consequently, you can find yourself in a situation where calling this method throws an uncaught exception.

I'm running into this when loading ~60 images into memory using `twgl.createTextures` and then calling this method after the images are loaded. Sometimes this method errors when I am doing this, perhaps due to some race condition? I'm not sure the specific cause, but this change makes this function type safe, and ensures the uncaught exception will never happen.