### PR TITLE
fix: enable the expo-gl version of gl.texImage2D

### DIFF
--- a/src/textures.js
+++ b/src/textures.js
@@ -1643,12 +1643,10 @@ function createTexture(gl, options, callback) {
       } else {
         loadSlicesFromUrls(gl, tex, options, callback);
       }
-    } else if (isTexImageSource(src)) {
+    } else {
       setTextureFromElement(gl, tex, src, options);
       width  = src.width;
       height = src.height;
-    } else {
-      throw "unsupported src type";
     }
   } else {
     setEmptyTexture(gl, tex, options);


### PR DESCRIPTION
fix #163 