### PR TITLE
Fix framebuffer target value

### DIFF
--- a/src/framebuffers.js
+++ b/src/framebuffers.js
@@ -234,7 +234,7 @@ function createFramebufferInfo(gl, attachments, width, height) {
         gl.framebufferTexture2D(
             target,
             attachmentPoint,
-            attachmentOptions.texTarget || TEXTURE_2D,
+            attachmentOptions.target || TEXTURE_2D,
             attachment,
             attachmentOptions.level || 0);
       }


### PR DESCRIPTION
It seems to be a typo. As I can see, `texTarget` is some legacy property and unsupported now