### PR TITLE
add `util` and `helper` to keywords list

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   },
   "keywords": [
     "WebGL",
-    "twgl"
+    "twgl",
+    "util",
+    "helper"
   ],
   "author": "Greggman",
   "license": "MIT",


### PR DESCRIPTION
By doing this it would be possible to find your package with this keywords ...