### PR TITLE
fix: make compatible with TypeScript 4.3

### DIFF
--- a/src/framebuffers.js
+++ b/src/framebuffers.js
@@ -94,7 +94,7 @@ const LINEAR                         = 0x2601;
  * @property {number} [level] level for `gl.framebufferTexture2D`. Defaults to 0.
  * @property {number} [layer] layer for `gl.framebufferTextureLayer`. Defaults to undefined.
  *   If set then `gl.framebufferTextureLayer` is called, if not then `gl.framebufferTexture2D`
- * @property {WebGLObject} [attachment] An existing renderbuffer or texture.
+ * @property {(WebGLRenderbuffer | WebGLTexture)} [attachment] An existing renderbuffer or texture.
  *    If provided will attach this Object. This allows you to share
  *    attachments across framebuffers.
  * @memberOf module:twgl
@@ -137,7 +137,7 @@ function isRenderbufferFormat(format) {
 /**
  * @typedef {Object} FramebufferInfo
  * @property {WebGLFramebuffer} framebuffer The WebGLFramebuffer for this framebufferInfo
- * @property {WebGLObject[]} attachments The created attachments in the same order as passed in to {@link module:twgl.createFramebufferInfo}.
+ * @property {Array.<(WebGLRenderbuffer | WebGLTexture)>} attachments The created attachments in the same order as passed in to {@link module:twgl.createFramebufferInfo}.
  * @property {number} width The width of the framebuffer and its attachments
  * @property {number} height The width of the framebuffer and its attachments
  * @memberOf module:twgl


### PR DESCRIPTION
In TypeScript 4.3, `WebGLObject` was dropped from `lib.dom.d.ts`.
This commit replaces uses of `WebGLObject` with `WebGLRenderbuffer|WebGLTexture`.
Based on reading TWGL's `createFramebufferInfo(...)` these two are the
only possible object types for attachments in `FramebufferInfo`.

Relevant TypeScript changes:
[Justification for removal of `WebGLObject`](https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/991)
[Removal of `WebGLObject`](https://github.com/microsoft/TypeScript/pull/44423)