### PR TITLE
Experiment with uniform-tree support

### DIFF
--- a/test/webgl.js
+++ b/test/webgl.js
@@ -1,4 +1,5 @@
 import {it} from './mocha-support.js';
+import {assertArrayEqual} from './assert.js';
 
 export function createContext() {
   const gl = document.createElement('canvas').getContext('webgl');
@@ -32,6 +33,12 @@ export function resetContexts(context) {
     gl2.bindVertexArray(null);
     resetContext(gl2);
   }
+}
+
+export function checkColor(gl, color) {
+  const p = new Uint8Array(4);
+  gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, p);
+  assertArrayEqual(p, color);
 }
 
 export function escapeRE(str) {


### PR DESCRIPTION
This is just an experiement. I haven't decided if this is going to be added or not

Trying out, given uniforms like this.

```
    struct Extra {
      float f;
      vec4 v4;
      vec3 v3;
    };
    struct Light {
      float intensity;
      vec4 color;
      float nearFar[2];
      Extra extra[2];
    };
    uniform Light lights[2];
```

You can set them like this

```
twgl.setUniformTree(programInfo, {
  lights:[
    { intensity: 1.5, color: [1, 0, 0, 1], nearFar: [0.1, 1.0], extra: [ f: 0.1, v4: [1.2, 3.4, 1.2, 1.4], v3: [0, 1, 2], },
    { intensity: 2.3, color: [0, 0, 1, 1], nearFar: [0.1, 1.0], extra: [ f: 0.7, v4: [3.1, 7.9, 0.6, 5.8], v3: [4, 5, 6], },
  ],
});
```