### PR TITLE
replace error with warning

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -518,7 +518,7 @@ function getNumElementsFromAttributes(gl, attribs) {
   if (numElements % 1 !== 0) {
     console.warn(`numComponents ${numComponents} not correct for length ${length}`);
   }
-  return numElements;
+  return Math.floor(numElements);
 }
 
 /**

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -516,7 +516,7 @@ function getNumElementsFromAttributes(gl, attribs) {
   // TODO: check stride
   const numElements = totalElements / numComponents;
   if (numElements % 1 !== 0) {
-    throw new Error(`numComponents ${numComponents} not correct for length ${length}`);
+    console.warn(`numComponents ${numComponents} not correct for length ${length}`);
   }
   return numElements;
 }


### PR DESCRIPTION
Hi, thanks for TWGL!

I noticed that `getNumElementsFromAttributes`, called from `createBufferInfoFromArrays`, currently throws an error when the buffer size does not evenly divide the attribute size. 

However, there are valid use cases for having an uneven division, such as reusing a large, preallocated webgl buffer to render different kinds of geometry. This PR changes the error to a warning, since this situation may be indicative of a bug in the user's code in the common case.

In my app I have a WASM core that passes data to a JS renderer, which copies it into a preallocated webgl buffer. Geometry types can differ across frames, which is how I ran into this bug — some of them did not evenly divide the buffer size, even though the buffer is intended to be large enough to hold the maximum possible amount of geometry each frame, so it would never reach the end of the buffer.

