### PR TITLE
Always call vertexAttribDivisor

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -198,7 +198,7 @@ function makeTypedArray(array, name) {
  * @property {boolean} [normalize] whether or not to normalize the data. Default = false
  * @property {number} [offset] offset into buffer in bytes. Default = 0
  * @property {number} [stride] the stride in bytes per element. Default = 0
- * @property {number} [divisor] the divisor in instances. Default = undefined. Note: undefined = don't call gl.vertexAttribDivisor
+ * @property {number} [divisor] the divisor in instances. Default = 0
  *    where as anything else = do call it with this value
  * @property {WebGLBuffer} buffer the buffer that contains the data for this attribute
  * @property {number} [drawType] the draw type passed to gl.bufferData. Default = gl.STATIC_DRAW
@@ -221,7 +221,7 @@ function makeTypedArray(array, name) {
  * @property {boolean} [normalize] normalize for `vertexAttribPointer`. Default is true if type is `Int8Array` or `Uint8Array` otherwise false.
  * @property {number} [stride] stride for `vertexAttribPointer`. Default = 0
  * @property {number} [offset] offset for `vertexAttribPointer`. Default = 0
- * @property {number} [divisor] divisor for `vertexAttribDivisor`. Default = undefined. Note: undefined = don't call gl.vertexAttribDivisor
+ * @property {number} [divisor] divisor for `vertexAttribDivisor`. Default = 0
  *    where as anything else = do call it with this value
  * @property {string} [attrib] name of attribute this array maps to. Defaults to same name as array prefixed by the default attribPrefix.
  * @property {string} [name] synonym for `attrib`.

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -198,8 +198,7 @@ function makeTypedArray(array, name) {
  * @property {boolean} [normalize] whether or not to normalize the data. Default = false
  * @property {number} [offset] offset into buffer in bytes. Default = 0
  * @property {number} [stride] the stride in bytes per element. Default = 0
- * @property {number} [divisor] the divisor in instances. Default = 0
- *    where as anything else = do call it with this value
+ * @property {number} [divisor] the divisor in instances. Default = 0.  Requires WebGL2 or the ANGLE_instanced_arrays extension.
  * @property {WebGLBuffer} buffer the buffer that contains the data for this attribute
  * @property {number} [drawType] the draw type passed to gl.bufferData. Default = gl.STATIC_DRAW
  * @memberOf module:twgl
@@ -221,8 +220,7 @@ function makeTypedArray(array, name) {
  * @property {boolean} [normalize] normalize for `vertexAttribPointer`. Default is true if type is `Int8Array` or `Uint8Array` otherwise false.
  * @property {number} [stride] stride for `vertexAttribPointer`. Default = 0
  * @property {number} [offset] offset for `vertexAttribPointer`. Default = 0
- * @property {number} [divisor] divisor for `vertexAttribDivisor`. Default = 0
- *    where as anything else = do call it with this value
+ * @property {number} [divisor] divisor for `vertexAttribDivisor`. Default = 0.  Requires WebGL2 or the ANGLE_instanced_arrays extension.
  * @property {string} [attrib] name of attribute this array maps to. Defaults to same name as array prefixed by the default attribPrefix.
  * @property {string} [name] synonym for `attrib`.
  * @property {string} [attribName] synonym for `attrib`.

--- a/src/programs.js
+++ b/src/programs.js
@@ -395,7 +395,9 @@ function floatAttribSetter(gl, index) {
       gl.enableVertexAttribArray(index);
       gl.vertexAttribPointer(
           index, b.numComponents || b.size, b.type || FLOAT, b.normalize || false, b.stride || 0, b.offset || 0);
-      gl.vertexAttribDivisor(index, b.divisor || 0);
+      if (gl.vertexAttribDivisor) {
+        gl.vertexAttribDivisor(index, b.divisor || 0);
+      }
     }
   };
 }
@@ -414,7 +416,9 @@ function intAttribSetter(gl, index) {
       gl.enableVertexAttribArray(index);
       gl.vertexAttribIPointer(
           index, b.numComponents || b.size, b.type || INT, b.stride || 0, b.offset || 0);
-      gl.vertexAttribDivisor(index, b.divisor || 0);
+      if (gl.vertexAttribDivisor) {
+        gl.vertexAttribDivisor(index, b.divisor || 0);
+      }
     }
   };
 }
@@ -433,7 +437,9 @@ function uintAttribSetter(gl, index) {
       gl.enableVertexAttribArray(index);
       gl.vertexAttribIPointer(
           index, b.numComponents || b.size, b.type || UNSIGNED_INT, b.stride || 0, b.offset || 0);
-      gl.vertexAttribDivisor(index, b.divisor || 0);
+      if (gl.vertexAttribDivisor) {
+        gl.vertexAttribDivisor(index, b.divisor || 0);
+      }
     }
   };
 }
@@ -456,7 +462,9 @@ function matAttribSetter(gl, index, typeInfo) {
       gl.enableVertexAttribArray(index + i);
       gl.vertexAttribPointer(
           index + i, size, type, normalize, stride, offset + rowOffset * i);
-      gl.vertexAttribDivisor(index + i, b.divisor || 0);
+      if (gl.vertexAttribDivisor) {
+        gl.vertexAttribDivisor(index + i, b.divisor || 0);
+      }
     }
   };
 }

--- a/src/programs.js
+++ b/src/programs.js
@@ -395,9 +395,7 @@ function floatAttribSetter(gl, index) {
       gl.enableVertexAttribArray(index);
       gl.vertexAttribPointer(
           index, b.numComponents || b.size, b.type || FLOAT, b.normalize || false, b.stride || 0, b.offset || 0);
-      if (b.divisor !== undefined) {
-        gl.vertexAttribDivisor(index, b.divisor);
-      }
+      gl.vertexAttribDivisor(index, b.divisor || 0);
     }
   };
 }
@@ -416,9 +414,7 @@ function intAttribSetter(gl, index) {
       gl.enableVertexAttribArray(index);
       gl.vertexAttribIPointer(
           index, b.numComponents || b.size, b.type || INT, b.stride || 0, b.offset || 0);
-      if (b.divisor !== undefined) {
-        gl.vertexAttribDivisor(index, b.divisor);
-      }
+      gl.vertexAttribDivisor(index, b.divisor || 0);
     }
   };
 }
@@ -437,9 +433,7 @@ function uintAttribSetter(gl, index) {
       gl.enableVertexAttribArray(index);
       gl.vertexAttribIPointer(
           index, b.numComponents || b.size, b.type || UNSIGNED_INT, b.stride || 0, b.offset || 0);
-      if (b.divisor !== undefined) {
-        gl.vertexAttribDivisor(index, b.divisor);
-      }
+      gl.vertexAttribDivisor(index, b.divisor || 0);
     }
   };
 }
@@ -462,9 +456,7 @@ function matAttribSetter(gl, index, typeInfo) {
       gl.enableVertexAttribArray(index + i);
       gl.vertexAttribPointer(
           index + i, size, type, normalize, stride, offset + rowOffset * i);
-      if (b.divisor !== undefined) {
-        gl.vertexAttribDivisor(index + i, b.divisor);
-      }
+      gl.vertexAttribDivisor(index + i, b.divisor || 0);
     }
   };
 }


### PR DESCRIPTION
Previously, if the divisor property was absent, the gl.vertexAttribDivisor call would be omitted, which caused the divisor value to be inherited from the
previous program.

With this change, an absent divisor causes an explicit call to gl.vertexAttribDivisor with parameter zero.

Note this is a breaking change if people have been deliberately or accidentally carrying divisor values forward from one program to the next.