### PR TITLE
Add missing `drawType` property to `FullArraySpec`

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -221,6 +221,7 @@ function makeTypedArray(array, name) {
  * @property {string} [attrib] name of attribute this array maps to. Defaults to same name as array prefixed by the default attribPrefix.
  * @property {string} [name] synonym for `attrib`.
  * @property {string} [attribName] synonym for `attrib`.
+ * @property {number} [drawType] the draw type passed to gl.bufferData. Default = gl.STATIC_DRAW
  * @memberOf module:twgl
  */
 


### PR DESCRIPTION
Have been having to use `// @ts-ignore` in my project to use this property, but it looks like it's valid: it's consumed in the `createAttribsFromArray` function here: https://github.com/greggman/twgl.js/blob/2bd840a29c88050efa3dae9e2cc676bd7ca666be/src/attributes.js#L432